### PR TITLE
Use smack fork while we wait for canonical

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.igniterealtime.smack/smack "3.4.1"]
-                 [org.igniterealtime.smack/smackx "3.4.1"]
+                 [org.clojars.amcclosky/smack "3.4.1"]
+                 [org.clojars.amcclosky/smackx "3.4.1"]
                  [clj-http "0.9.1"]
                  [joda-time/joda-time "2.3"]
                  [com.draines/postal "1.11.1"]


### PR DESCRIPTION
canonical 3.4.1 version is not yet released, so let's use a
forked one to simplify deployment (on travis, for instance)
